### PR TITLE
Fix for config loading bug and multiple monitors

### DIFF
--- a/qscreenmapscene.cpp
+++ b/qscreenmapscene.cpp
@@ -8,7 +8,7 @@ QScreenMapScene::QScreenMapScene(QScreen *screen)
     : QGraphicsScene{}, screen{screen} {
     QTimer *timer;
 
-    setSceneRect(screen->geometry());
+    setSceneRect(screen->virtualGeometry());
 
     // initialize screen pixmap
     pixmapItem = new QGraphicsPixmapItem{QPixmap{0, 0}};
@@ -31,6 +31,9 @@ void QScreenMapScene::updateScreenMapPreview() {
     QPixmap pixmap = screen->grabWindow(0).scaled(sceneRect().size().toSize(),
                                                   Qt::KeepAspectRatio,
                                                   Qt::FastTransformation);
+    int32_t x1, y1, x2, y2;
+    screen->geometry().getCoords(&x1, &y1, &x2, &y2);
+    pixmapItem->setOffset(x1, y1);
     pixmapItem->setPixmap(pixmap);
 }
 

--- a/veikkparms.cpp
+++ b/veikkparms.cpp
@@ -87,7 +87,7 @@ VeikkParms::VPStatus VeikkParms::loadFromFile(QString src) {
     };
     sm = QRect {
         settings.value("screen_map/x").toInt(),
-        settings.value("screen_map/x").toInt(),
+        settings.value("screen_map/y").toInt(),
         settings.value("screen_map/width").toInt(),
         settings.value("screen_map/height").toInt()
     };


### PR DESCRIPTION
veikkparms.cpp:90:  
  Fixed a bug when loading a saved config that results in screen_map.x
  being loaded into the y position of the sm QRect.position

qscreenmapscene.cpp:34:
  The scene now draws properly when the primary monitor is not the
  leftmost monitor.  It doesn't *support* multiple monitors, but it
  *handles* them.